### PR TITLE
_layouts/default.html: fix video gallery

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -73,6 +73,7 @@
         children: 'a',
         pswpModule: PhotoSwipe
       });
+      const videoPlugin_{{gallery_id}} = new PhotoSwipeVideoPlugin(lightbox_{{gallery_id}}, {});
       lightbox_{{gallery_id}}.init();
       {% endfor %}
     </script>


### PR DESCRIPTION
Fix a missing initialisation of the video plugin on the lightbox in the default.html layout. This fixes a bug where the videos opened in a new tab instead of in the lightbox.