### PR TITLE
_syntax.scss: default highlight bg to dark mode

### DIFF
--- a/_sass/_syntax.scss
+++ b/_sass/_syntax.scss
@@ -1,6 +1,6 @@
 
 .highlight {
-	background: #ffffff;
+	background: #3b3c3c;
 	.c { color: #ccccc4; font-style: italic } /* Comment */
 	.err { color: #d38b8b; background-color: #e3d2d2 } /* Error */
 	.k { font-weight: bold } /* Keyword */


### PR DESCRIPTION
Try to fix a bug where some code sections have a white background with grey text (depending on what code language is being displayed). Seen with plain text code snippets.